### PR TITLE
Fix build image tsconfig error

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,26 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["server/**/*", "shared/**/*"],
+  "exclude": ["node_modules", "build", "dist", "**/*.test.ts", "client/**/*"],
+  "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/typescript/tsbuildinfo-server",
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "module": "ESNext",
+    "target": "ES2022",
+    "strict": true,
+    "lib": ["ES2022"],
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "types": ["node"],
+    "paths": {
+      "@shared/*": ["./shared/*"]
+    },
+    "declaration": false,
+    "sourceMap": false
+  }
+}


### PR DESCRIPTION
Add `tsconfig.build.json` to enable server-side TypeScript compilation and fix Docker build failures.

The Docker build failed because the `build:server` script required `tsconfig.build.json`, which was missing. This new file provides a dedicated configuration to compile server-side TypeScript into the `dist` directory, separate from the client-side build and the main `tsconfig.json` which had `noEmit: true`.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f4051a6-2738-4f10-95cf-860a8629a86b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f4051a6-2738-4f10-95cf-860a8629a86b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

